### PR TITLE
db.update set NULL for Type.TEXT field

### DIFF
--- a/db/dialect/ANSI.java
+++ b/db/dialect/ANSI.java
@@ -193,6 +193,10 @@ public abstract class ANSI extends DB {
                 st.setNull (n, Types.BLOB);
                 break;
 
+            case CLOB:
+                st.setNull (n, Types.CLOB);
+                break;
+
             default: 
                 logger.warning ("Setting OTHER NULL for :" + n);
                 st.setNull (n, Types.OTHER);


### PR DESCRIPTION
```
final Map<String, Object> h = DB.HASH (
	"uuid", uuid
);

h.putAll (DB.HASH (
	"rp_cred_uuid", rpCredUuid,
	"rp", null
));

db.update (OutSoap.class, h);
```


> мая 06, 2020 2:39:02 PM ru.eludia.base.db.dialect.ANSI setNullParam
> WARNING: Setting OTHER NULL for :5
> мая 06, 2020 2:39:02 PM ru.eludia.base.DB execute
> SEVERE: Invalid column type: 1111 for UPDATE out_soap SET cred_error=?,rq_cred_uuid=?,id_cred_status=?,rp_cred_uuid=?,rp=?,rq=? WHERE uuid=?
> java.sql.SQLException: Invalid column type: 1111
> 	at oracle.jdbc.driver.OracleStatement.getInternalType(OracleStatement.java:3978)
> 	at oracle.jdbc.driver.OraclePreparedStatement.setNullCritical(OraclePreparedStatement.java:4472)
> 	at oracle.jdbc.driver.OraclePreparedStatement.setNull(OraclePreparedStatement.java:4456)
> 	at oracle.jdbc.driver.OraclePreparedStatementWrapper.setNull(OraclePreparedStatementWrapper.java:1008)
> 	at weblogic.jdbc.wrapper.PreparedStatement.setNull(PreparedStatement.java:460)
> 	at ru.eludia.base.db.dialect.ANSI.setNullParam(ANSI.java:198)
> 	at ru.eludia.base.db.dialect.ANSI.setParam(ANSI.java:207)